### PR TITLE
Add git-cm script

### DIFF
--- a/bin/git-cm
+++ b/bin/git-cm
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# git c(heckout)m(ain) is a script to abstract checking out the main branch.
+# This is helpful for master -> main conversions as well as worktrees where you
+# have a separate main branch that has to be named differently
+#
+
+set -euo pipefail
+
+config_key="$(git rev-parse --show-toplevel | md5).main-branch"
+if main_branch="$(git config --local "$config_key")"; then
+  git checkout "$main_branch"
+else
+  git checkout "$(git main-branch)"
+fi

--- a/bin/git-set-main-branch
+++ b/bin/git-set-main-branch
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# This script sets the appropriate git config key for use with `git-cm`
+#
+
+set -euo pipefail
+
+config_key="$(git rev-parse --show-toplevel | md5).main-branch"
+git config --local "$config_key" "$1"


### PR DESCRIPTION
I've been using a worktree as my primary checkout for some repos for a
while and I keep mistyping the main branch which is used in another
worktree.