### PR TITLE
Switch to fzf

### DIFF
--- a/bash/env.bash
+++ b/bash/env.bash
@@ -67,4 +67,6 @@ export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 export GH_NO_UPDATE_NOTIFIER=1
 
+export FZF_DEFAULT_OPTS="--layout=reverse --height=11"
+
 ulimit -f unlimited

--- a/bin/find-files-async
+++ b/bin/find-files-async
@@ -16,62 +16,17 @@ if root=$(git rev-parse --show-toplevel 2>/dev/null); then
   fi
 fi
 
-hash_str() {
-  if command -v md5 >/dev/null; then
-    md5
+if [[ -n "$is_git" ]]; then
+  if [[ -n "$has_submodules" ]]; then
+    git ls-files "$search_dir" --cached --exclude-standard --recurse-submodules 2>/dev/null && \
+      git ls-files "$search_dir" --exclude-standard --others 2>/dev/null
   else
-    md5sum | cut -d" " -f1
+    git ls-files "$search_dir" --cached --exclude-standard --others 2>/dev/null
   fi
-}
-
-# The cache file is derived to make all of these requests unique results because
-# git-ls-files correctly relativizes outputs based on these factors.
-#
-# Search dir | actual path | pwd | result
-# -----------+-------------+-----+-------
-# .          | /something  | /   | a
-# /something | /something  | /   | b
-# /something | /something  | /sometime   | c
-readonly cache_dir=/tmp/find-files-async
-cache_file="$cache_dir/$(echo "$search_dir" | hash_str)-$(realpath "$search_dir" | hash_str)-$(pwd | hash_str)"
-mkdir -p "$cache_dir"
-
-run_cmd() {
-  if [[ -n "$is_git" ]]; then
-    if [[ -n "$has_submodules" ]]; then
-      git ls-files "$search_dir" --cached --exclude-standard --recurse-submodules 2>/dev/null && \
-        git ls-files "$search_dir" --exclude-standard --others 2>/dev/null
-    else
-      git ls-files "$search_dir" --cached --exclude-standard --others 2>/dev/null
-    fi
-  else
-    if command -v fdfind >/dev/null; then
-      fdfind --type file --type symlink "$search_dir"
-    else
-      fd --type file --type symlink "$search_dir"
-    fi
-  fi
-}
-
-# Initial file creation
-if [[ ! -r "$cache_file" ]]; then
-  run_cmd | tee "$cache_file"
-  exit 0
-fi
-
-# Happy path
-if [[ $OSTYPE == darwin* ]]; then
-  hours_since_change=$(( ($(date +%s) - $(stat -t %s -f %m "$cache_file")) / 3600 ))
 else
-  hours_since_change=$(( ($(date +%s) - $(stat -c %Y "$cache_file")) / 3600 ))
+  if command -v fdfind >/dev/null; then
+    fdfind --type file --type symlink "$search_dir"
+  else
+    fd --type file --type symlink "$search_dir"
+  fi
 fi
-
-if [[ "$hours_since_change" -lt 24 ]]; then
-  cat "$cache_file"
-  tmp=$(mktemp)
-  (run_cmd > "$tmp" && mv "$tmp" "$cache_file" ) &
-  exit 0
-fi
-
-# File too old, ignore it
-run_cmd | tee "$cache_file"

--- a/vim/plugin/fuzzy.vim
+++ b/vim/plugin/fuzzy.vim
@@ -19,7 +19,7 @@ function! FuzzyFindCommand(vimCommand) abort
   endfunction
 
   botright 10 new
-  let l:term_command = 'find-files-async | fzy > ' .  l:callback.filename
+  let l:term_command = 'find-files-async | fzf > ' .  l:callback.filename
   silent call termopen(l:term_command, l:callback)
   setlocal nonumber norelativenumber
   startinsert

--- a/zsh/fuzzy.zsh
+++ b/zsh/fuzzy.zsh
@@ -14,7 +14,7 @@ trim_quotes() {
 fuzzy_git_files_widget() {
   trap "" INT
 
-  result="$(find-files-async | fzy)"
+  result="$(find-files-async | fzf)"
   if [ "$result" != "" ]; then
     LBUFFER="${LBUFFER}\"$(trim_quotes $result)\""
   fi


### PR DESCRIPTION
In my initial testing fzf is just a lot faster than fzy for larger repos. I was trying to improve this before by caching the file searches (which an issue with untracked files today), but even with that it's just too slow. I prefer fzf's incremental loading contents approach, so I can start typing, even if the results take the same amount of time to get there. I'm still using fzy in some places for now, we'll see how that goes.